### PR TITLE
Fixed GetAllJobs and added test function for it

### DIFF
--- a/gointelowl.go
+++ b/gointelowl.go
@@ -72,10 +72,10 @@ func (client *IntelOwlClient) GetAllTags() []map[string]string {
 //		  Endpoint: ``/api/jobs``
 //  Returns:
 //	      []map[string]string: Slice of Jobs
-func (client *IntelOwlClient) GetAllJobs() []map[string]string {
+func (client *IntelOwlClient) GetAllJobs() []map[string]interface{} {
 	url := client.URL + "/api/jobs"
 	response := buildAndMakeGetRequest(url, client.Token)
-	var jobs []map[string]string
+	var jobs []map[string]interface{}
 	data, err := ioutil.ReadAll(response.Body)
 	if err != nil {
 		log.Fatalln(err)

--- a/gointelowl_test.go
+++ b/gointelowl_test.go
@@ -1,6 +1,7 @@
 package gointelowl
 
 import (
+	"fmt"
 	"log"
 	"net/http"
 	"reflect"
@@ -40,5 +41,18 @@ func TestBuildAndMakePostRequest(t *testing.T) {
 	response := buildAndMakePostRequest(URL, "", []byte("{}"))
 	if response.StatusCode != http.StatusCreated {
 		log.Fatalln("Expected status code : ", http.StatusOK, " got : ", response.StatusCode)
+	}
+}
+
+func TestGetAllJobs(t *testing.T) {
+	client := IntelOwlClient{
+		Token:       "95830471d0bc0c0595228f890c20beea",
+		URL:         "http://localhost:80",
+		Certificate: "",
+	}
+	jobs := client.GetAllJobs()
+	fmt.Println(len(jobs))
+	if len(jobs) == 0 {
+		log.Fatalln("Expected jobs to be greater than 0")
 	}
 }


### PR DESCRIPTION
I changed the type of jobs from `[]map[string]string` to `[]map[string]interface{}` bcz in the [API Docs](https://intelowl.readthedocs.io/en/latest/Redoc.html#operation/jobs_list) for `api/jobs` the return type isn't consistent for all the json fields `id` has type `int` `is_sample` has boolean type while most of the other fields have type string 
and `[]map[string]string` assumes every type to be of type string.

Added test for this function also
![Screenshot from 2021-11-21 22-22-50](https://user-images.githubusercontent.com/72073401/142771397-17705a29-c5b9-4a53-9f84-73ca3e6e1907.png)

