### PR TITLE
Refracted newRequest to use 1 io.ReadAll!

### DIFF
--- a/gointelowl/client.go
+++ b/gointelowl/client.go
@@ -56,7 +56,7 @@ type IntelOwlClient struct {
 // * enum for TLP attribute used in the IntelOwl API
 type TLP int
 
-//* making the values of TLP
+// * making the values of TLP
 const (
 	WHITE TLP = iota + 1
 	GREEN
@@ -97,12 +97,12 @@ func ParseTLP(s string) TLP {
 	return TLP(value)
 }
 
-//* Implementing the MarshalJSON interface to make our custom Marshal for the enum
+// * Implementing the MarshalJSON interface to make our custom Marshal for the enum
 func (tlp TLP) MarshalJSON() ([]byte, error) {
 	return json.Marshal(tlp.String())
 }
 
-//* Implementing the UnmarshalJSON interface to make our custom Unmarshal for the enum
+// * Implementing the UnmarshalJSON interface to make our custom Unmarshal for the enum
 func (tlp *TLP) UnmarshalJSON(data []byte) (err error) {
 	var tlpString string
 	if err := json.Unmarshal(data, &tlpString); err != nil {
@@ -172,28 +172,24 @@ func (client *IntelOwlClient) newRequest(ctx context.Context, request *http.Requ
 
 	defer response.Body.Close()
 
-	statusCode := response.StatusCode
-	if statusCode < http.StatusOK || statusCode >= http.StatusBadRequest {
-		msgBytes, err := ioutil.ReadAll(response.Body)
-		if err != nil {
-			errorMessage := fmt.Sprintf("Could not convert JSON response. Status code: %d", statusCode)
-			intelOwlError := newIntelOwlError(statusCode, errorMessage, response)
-			return nil, intelOwlError
-		}
-		errorMessage := string(msgBytes)
-		intelOwlError := newIntelOwlError(statusCode, errorMessage, response)
-		return nil, intelOwlError
-	}
-
 	msgBytes, err := ioutil.ReadAll(response.Body)
+	statusCode := response.StatusCode
 	if err != nil {
 		errorMessage := fmt.Sprintf("Could not convert JSON response. Status code: %d", statusCode)
 		intelOwlError := newIntelOwlError(statusCode, errorMessage, response)
 		return nil, intelOwlError
 	}
+
+	if statusCode < http.StatusOK || statusCode >= http.StatusBadRequest {
+		errorMessage := string(msgBytes)
+		intelOwlError := newIntelOwlError(statusCode, errorMessage, response)
+		return nil, intelOwlError
+	}
+
 	sucessResp := successResponse{
 		StatusCode: statusCode,
 		Data:       msgBytes,
 	}
+
 	return &sucessResp, nil
 }


### PR DESCRIPTION
# Description
    Refracted the `newRequest` method in `IntelOwlClient` to use one io.ReadAll as the second was redundant!

## Issues
add the related issue(s) your change tackles

## Type of change
list down the type of change
- [ ] Bug fix
- [ ] New feature (added a new endpoint or created)
- [ ] Breaking fix (a bug fix or new feature that would cause exisiting functionality not to work as expected)

## Checklist
- [ ] if a new feature was added it passed all its (if made) test cases 
- [ ] if a bug fix was added it passed all its existing test cases 

### Important Rules
- If your changes decrease the overall tests coverage (you will know after the Codecov CI job is done), you should add the required tests to fix the problem
- Everytime you make changes to the PR and you think the work is done, you should explicitly ask for a review



Please delete if the PR is for bug fixing.